### PR TITLE
pycvvdp: Introduce saving quality metrics by default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ imageio==2.19.5
 matplotlib==3.5.3
 PyEXR==0.3.10
 torchvision==0.13.0
+pandas=2.1.3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
                       'torchvision>=0.9.2',
                       'ffmpeg>=1.4',
                       'imageio>=2.19.5',
-                      'matplotlib>=3.8.0'
+                      'matplotlib>=3.8.0',
+                      'pandas>=2.1.3'
                      ],
 
     classifiers=[


### PR DESCRIPTION
This allows us to have a CSV file (can be extended to JSON/XML) in future for quality metrics computed by the program. By default it saves to $output/${basename}-metrics.csv format.

This is enabled by default because why not