### PR TITLE
pycvvdp: Sort the output for wildcharchars

### DIFF
--- a/pycvvdp/run_cvvdp.py
+++ b/pycvvdp/run_cvvdp.py
@@ -31,6 +31,11 @@ def expand_wildcards(filestrs):
     for filestr in filestrs:
         if "*" in filestr:
             curlist = glob.glob(filestr)
+            # Sort the files before feeding since glob is returing arbitary
+            # order, thus it can be actually comparing frame 2 with frame 80.
+            # We sort it with classic OS order so we will be good.
+            # Read more: https://docs.python.org/3/library/glob.html
+            curlist = sorted(curlist)
             files = files + curlist
         else:
             files.append(filestr)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ imageio==2.19.5
 matplotlib==3.5.3
 PyEXR==0.3.10
 torchvision==0.13.0
+pandas=2.1.3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
                       'torchvision>=0.9.2',
                       'ffmpeg>=1.4',
                       'imageio>=2.19.5',
-                      'matplotlib>=3.8.0'
+                      'matplotlib>=3.8.0',
+                      'pandas>=2.1.3'
                      ],
 
     classifiers=[


### PR DESCRIPTION
This is problematic if we do not sort when we feed two folders.
Python does not care about frame orders, but we care, so in some cases,
it was comparing Frame 2 with Frame 90. So to be correct, we
sort it before returning the list.


PS: Will rebase once #7 is merged