### PR TITLE
Fix import for expand_dims which moved in NumPy 2.0

### DIFF
--- a/pycvvdp/cvvdp_metric.py
+++ b/pycvvdp/cvvdp_metric.py
@@ -1,6 +1,9 @@
 from abc import abstractmethod
 from urllib.parse import ParseResultBytes
-from numpy.lib.shape_base import expand_dims
+try:
+    from numpy import expand_dims
+except ImportErorr:
+    from numpy.lib.shape_base import expand_dims
 import math
 import torch
 from torch.utils import checkpoint


### PR DESCRIPTION
Keep fallback to old import path to support older version (from requirements.txt)