### PR TITLE
fix custom-display rendering in output

### DIFF
--- a/pycvvdp/cvvdp_metric.py
+++ b/pycvvdp/cvvdp_metric.py
@@ -230,7 +230,10 @@ class cvvdp(vq_metric):
             self.display_name = display_name
         else:
             self.display_photometry = display_photometry
-            self.display_name = "unspecified"
+            if hasattr(display_photometry, 'short_name'):
+                self.display_name = display_photometry.short_name
+            else:
+                self.display_name = "unspecified"
         
         if display_geometry is None:
             self.display_geometry = vvdp_display_geometry.load(display_name, config_paths)


### PR DESCRIPTION
The display model passed to `--display` does not print out properly because `display_photometry` is loaded in `run_cvvdp.py` and passed down rather than loaded by name in `set_display_model`, however it should arguably still print the key that was used to load it from `display_models.json`

before:

```
[INFO] "ColorVideoVDP v0.4.1, 159.6 [pix/deg], Lpeak=1025, Lblack=0.0004, Lrefl=0.3979 [cd/m^2], (custom-display: unspecified)"
```

after

```
[INFO] "ColorVideoVDP v0.4.1, 159.6 [pix/deg], Lpeak=1025, Lblack=0.0004, Lrefl=0.3979 [cd/m^2], (custom-display: iiphone_12_pro)"
```