### PR TITLE
Batch interpolation for csf

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# v0.4.? (?)
+* Interpolation of the CSF is a bit faster now (thanks to Dongyeon)
+
 # v0.4.2 (29/09/2024)
 * Files are now sorted after the wildcard expansion
 * Updated PU21 encoding parameters so that they are in sync with those in https://github.com/gfxdisp/pu21/

--- a/pycvvdp/csf.py
+++ b/pycvvdp/csf.py
@@ -1,49 +1,7 @@
 import torch
 import pycvvdp.utils as utils
 
-# from interp import interp1 # deprecated
-
-def linear_interp(x, xp, fp):
-    """
-    Perform linear interpolation for the given input of PyTorch tensors
-    """
-    # Get the indices where xp[j] <= x < xp[j+1]
-    idx = torch.searchsorted(xp, x, right=True) - 1
-    idx = torch.clamp(idx, 0, len(xp) - 2)  # Clamping to avoid index out of bounds
-
-    # Slope for each segment
-    slope = (fp[idx + 1] - fp[idx]) / (xp[idx + 1] - xp[idx])
-
-    # Linear interpolation
-    return fp[idx] + slope * (x - xp[idx])
-
-def batch_interp1d(x, xp, fp):
-    """
-    Perform batch-wise linear interpolation.
-    """
-    # Ensure xp is increasing
-    assert torch.all(xp[1:] >= xp[:-1]), "xp must be in increasing order"
-
-    # Make tensors contiguous to avoid warnings and optimize performance
-    x = x.contiguous()
-    xp = xp.contiguous()
-    fp = fp.contiguous()
-
-    # Find indices of the closest points
-    indices = torch.searchsorted(xp, x) - 1
-    indices = torch.clamp(indices, 0, len(xp) - 2)
-
-    # Gather the relevant points
-    x0 = xp[indices]
-    x1 = xp[indices + 1]
-    y0 = fp[torch.arange(fp.shape[0]), indices]
-    y1 = fp[torch.arange(fp.shape[0]), indices + 1]
-
-    # Compute the slope
-    slope = (y1 - y0) / (x1 - x0)
-
-    # Compute the interpolated values
-    return y0 + slope * (x - x0)
+from interp import interp1q, batch_interp1d
 
 class castleCSF:
 
@@ -83,11 +41,12 @@ class castleCSF:
             logS_r = self.logS_rho[rho_str]
         else:
             N = self.log_L_bkg.numel()
+            logS_r = torch.empty((N), device=self.device)
             logS_r = batch_interp1d(torch.log10(torch.as_tensor(rho, device=self.device, dtype=torch.float32)).expand(N), self.log_rho, logS)
-            self.logS_rho[rho_str] = logS_r
+            self.logS_rho[rho_str] = logS_r        
 
         # Then, interpolate across luminance levels    
-        S = 10**linear_interp( logL_bkg, self.log_L_bkg, logS_r )        
+        S = 10**interp1q( self.log_L_bkg, logS_r, logL_bkg )
 
         return S
 


### PR DESCRIPTION
I substituted the 1D interpolation in csf.py.
Before it was iterating over the contrast band channel and it was a major bottleneck for the slow inference time.
I applied batch interpolation to resolve this issue.

For the test, I ran test_profiler with cvvdp functions and this is the result of the speed compared in my local env (gpu: 2080 RTX)
![Test_result](https://github.com/user-attachments/assets/7195b926-9a39-4988-80cd-701d6b51ac17)
